### PR TITLE
Use simple selector for :not(X) in assert-selector

### DIFF
--- a/scss/mixins/_accessibility.scss
+++ b/scss/mixins/_accessibility.scss
@@ -9,8 +9,10 @@
 
 // Assert that the parent selector matches one of the selectors passed into $selectors
 @mixin assert-selector($selectors...) {
-    &:not(#{$selectors}) {
-        /*! You must ensure the element matches one of these selectors: #{$selectors} */
-        outline: 2px solid red !important;
+    /*! You must ensure the element matches one of these selectors: #{$selectors} */
+    @each $selector in $selectors {
+        &:not(#{$selector}) {
+            outline: 2px solid red !important;
+        }
     }
 }


### PR DESCRIPTION
in CSS3, `:not(X)` takes a simple selector.

> 6.6.7. The negation pseudo-class
> The negation pseudo-class, :not(X), is a functional notation taking a simple selector (excluding the negation pseudo-class itself) as an argument.
> http://www.w3.org/TR/css3-selectors/#negation
