### PR TITLE
Add pointer-events: none to disabled buttons

### DIFF
--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -44,8 +44,8 @@ $DBbutton-border-tertiary: color(blue) !default;
 
     &[disabled], &#{&}--disabled {
         opacity: 0.5;
-        pointer-events: none;
         cursor: default;
+        pointer-events: none;
     }
 
     &:focus {

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -44,7 +44,7 @@ $DBbutton-border-tertiary: color(blue) !default;
 
     &[disabled], &#{&}--disabled {
         opacity: 0.5;
-
+        pointer-events: none;
         cursor: default;
     }
 


### PR DESCRIPTION
Hey Dan! We're very interested in your work here. I noticed that you don't have [pointer-events](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) set to `none` on disabled buttons.

This rule has been very helpful in preventing bugs where users try to click on things that are disabled and some programmers ( :neutral_face: ) don't have very good error handling. Thought you'd like to consider it!
