### PR TITLE
Rewording of WCAG Color Contrast Compliance

### DIFF
--- a/docs/source/functions.erb
+++ b/docs/source/functions.erb
@@ -37,8 +37,7 @@ toc:
   <aside class="sc-note">
     <h3>WCAG Color Contrast Compliance</h3>
     <p>Some of the colors in Scooter's <code>color</code> and <code>grayscale</code> functions meet the WCAG 2.0 AA color
-      contrast standards. Those colors have been indicated in the preview below. This means that the colors are safe to
-      use against a white background.</p>
+      contrast standards <strong>when used against a white background</strong>. Those colors have been indicated in the preview below.</p>
   </aside>
 
   <h3 id="grayscale">grayscale($gradation, [$alpha: 1])</h3>


### PR DESCRIPTION
this avoids burying the lede that compliance depends on the white background
