### PR TITLE
Redesign Type Scale

### DIFF
--- a/css/scooter.css
+++ b/css/scooter.css
@@ -79,12 +79,14 @@ html, :root {
   line-height: 23px; }
 
 a,
-.f-a {
+.f-a,
+.f-link {
   text-decoration: none;
   color: #007ee5;
   cursor: pointer; }
   a:hover,
-  .f-a:hover {
+  .f-a:hover,
+  .f-link:hover {
     text-decoration: underline; }
 
 hr {
@@ -1271,6 +1273,11 @@ select.c-input {
   .c-typeahead__media {
     margin-right: 12px; }
 
+.c-rule {
+  margin-bottom: 23px;
+  border: 0;
+  border-top: 1px solid rgba(37, 40, 43, 0.1); }
+
 .ax-visually-hidden {
   position: absolute !important;
   border: 0 !important;
@@ -1303,6 +1310,12 @@ select.c-input {
   .u-unbutton::-moz-focus-inner {
     border: 0;
     padding: 0; }
+
+.u-trim-margin {
+  margin: 0 !important; }
+
+.u-trim-padding {
+  padding: 0 !important; }
 
 .u-pad-xxs {
   padding: 4px !important; }
@@ -1580,12 +1593,6 @@ select.c-input {
   margin-left: 64px !important;
   margin-right: 64px !important; }
 
-.u-trim-margin {
-  margin: 0 !important; }
-
-.u-trim-padding {
-  padding: 0 !important; }
-
 .u-l-fl {
   float: left !important; }
 
@@ -1617,7 +1624,8 @@ select.c-input {
   text-align: right !important; }
 
 .u-font-small {
-  font-size: 0.85em; }
+  font-size: 0.85em;
+  line-height: 1.8; }
 
 .u-font-strong {
   font-weight: 600; }

--- a/css/scooter.css
+++ b/css/scooter.css
@@ -1305,6 +1305,12 @@ select.c-input {
     border: 0;
     padding: 0; }
 
+.u-trim-margin {
+  margin: 0 !important; }
+
+.u-trim-padding {
+  padding: 0 !important; }
+
 .u-pad-xxs {
   padding: 4px !important; }
 
@@ -1581,11 +1587,97 @@ select.c-input {
   margin-left: 64px !important;
   margin-right: 64px !important; }
 
-.u-trim-margin {
-  margin: 0 !important; }
+.u-pad-xxl {
+  padding: 96px !important; }
 
-.u-trim-padding {
-  padding: 0 !important; }
+.u-mar-xxl {
+  margin: 96px !important; }
+
+.u-pad-top-xxl {
+  padding-top: 96px !important; }
+
+.u-mar-top-xxl {
+  margin-top: 96px !important; }
+
+.u-pad-right-xxl {
+  padding-right: 96px !important; }
+
+.u-mar-right-xxl {
+  margin-right: 96px !important; }
+
+.u-pad-bottom-xxl {
+  padding-bottom: 96px !important; }
+
+.u-mar-bottom-xxl {
+  margin-bottom: 96px !important; }
+
+.u-pad-left-xxl {
+  padding-left: 96px !important; }
+
+.u-mar-left-xxl {
+  margin-left: 96px !important; }
+
+.u-pad-vertical-xxl {
+  padding-top: 96px !important;
+  padding-bottom: 96px !important; }
+
+.u-mar-vertical-xxl {
+  margin-top: 96px !important;
+  margin-bottom: 96px !important; }
+
+.u-pad-horizontal-xxl {
+  padding-left: 96px !important;
+  padding-right: 96px !important; }
+
+.u-mar-horizontal-xxl {
+  margin-left: 96px !important;
+  margin-right: 96px !important; }
+
+.u-pad-jumbo {
+  padding: 128px !important; }
+
+.u-mar-jumbo {
+  margin: 128px !important; }
+
+.u-pad-top-jumbo {
+  padding-top: 128px !important; }
+
+.u-mar-top-jumbo {
+  margin-top: 128px !important; }
+
+.u-pad-right-jumbo {
+  padding-right: 128px !important; }
+
+.u-mar-right-jumbo {
+  margin-right: 128px !important; }
+
+.u-pad-bottom-jumbo {
+  padding-bottom: 128px !important; }
+
+.u-mar-bottom-jumbo {
+  margin-bottom: 128px !important; }
+
+.u-pad-left-jumbo {
+  padding-left: 128px !important; }
+
+.u-mar-left-jumbo {
+  margin-left: 128px !important; }
+
+.u-pad-vertical-jumbo {
+  padding-top: 128px !important;
+  padding-bottom: 128px !important; }
+
+.u-mar-vertical-jumbo {
+  margin-top: 128px !important;
+  margin-bottom: 128px !important; }
+
+.u-pad-horizontal-jumbo {
+  padding-left: 128px !important;
+  padding-right: 128px !important; }
+
+.u-mar-horizontal-jumbo {
+  margin-left: 128px !important;
+  margin-right: 128px !important; }
 
 .u-l-fl {
   float: left !important; }

--- a/css/scooter.css
+++ b/css/scooter.css
@@ -48,41 +48,35 @@ html, :root {
   font: 81.25%/1.75 "Open Sans", "Helvetica Neue", Arial, sans-serif;
   color: #3d464d; }
 
-h1,
-.f-alpha {
+.f-headline, .f-subhead,
+.f1, .f2, .f3, .f4 {
   display: block;
   margin-bottom: 23px;
-  font-size: 28px;
-  font-weight: 200;
-  line-height: 36px; }
-
-h2,
-.f-beta {
-  display: block;
-  margin-bottom: 23px;
-  font-size: 20px;
   font-weight: 400;
-  line-height: 28px; }
+  line-height: 1.25; }
 
-h3,
-.f-gamma {
-  display: block;
-  margin-bottom: 23px;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 28px; }
+.f-headline {
+  font-size: 48px;
+  font-weight: 200; }
 
-h4,
-.f-delta {
-  display: block;
+.f-subhead {
+  font-size: 36px;
+  font-weight: 200; }
+
+.f1 {
+  font-size: 24px; }
+
+.f2 {
+  font-size: 20px; }
+
+.f3 {
+  font-size: 16px; }
+
+.f4 {
+  margin-bottom: 0;
   font-size: 13px;
   font-weight: 600;
   line-height: 23px; }
-
-hr {
-  margin-bottom: 23px;
-  border: 0;
-  border-top: 1px solid rgba(37, 40, 43, 0.1); }
 
 a,
 .f-a {
@@ -92,6 +86,11 @@ a,
   a:hover,
   .f-a:hover {
     text-decoration: underline; }
+
+hr {
+  margin-bottom: 23px;
+  border: 0;
+  border-top: 1px solid rgba(37, 40, 43, 0.1); }
 
 .o-wrap {
   display: block;
@@ -1641,6 +1640,12 @@ select.c-input {
 
 .u-font-nowrap {
   white-space: nowrap; }
+
+.u-font-caps {
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  -webkit-font-feature-settings: "c2sc" 1, "smcp" 1;
+          font-feature-settings: "c2sc" 1, "smcp" 1; }
 
 .u-thide {
   overflow: hidden;

--- a/css/scooter.css
+++ b/css/scooter.css
@@ -48,41 +48,35 @@ html, :root {
   font: 81.25%/1.75 "Open Sans", "Helvetica Neue", Arial, sans-serif;
   color: #3d464d; }
 
-h1,
-.f-alpha {
+.f-headline, .f-subhead,
+.f1, .f2, .f3, .f4 {
   display: block;
   margin-bottom: 23px;
-  font-size: 28px;
-  font-weight: 200;
-  line-height: 36px; }
-
-h2,
-.f-beta {
-  display: block;
-  margin-bottom: 23px;
-  font-size: 20px;
   font-weight: 400;
-  line-height: 28px; }
+  line-height: 1.25; }
 
-h3,
-.f-gamma {
-  display: block;
-  margin-bottom: 23px;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 28px; }
+.f-headline {
+  font-size: 48px;
+  font-weight: 200; }
 
-h4,
-.f-delta {
-  display: block;
+.f-subhead {
+  font-size: 36px;
+  font-weight: 200; }
+
+.f1 {
+  font-size: 24px; }
+
+.f2 {
+  font-size: 20px; }
+
+.f3 {
+  font-size: 16px; }
+
+.f4 {
+  margin-bottom: 0;
   font-size: 13px;
   font-weight: 600;
   line-height: 23px; }
-
-hr {
-  margin-bottom: 23px;
-  border: 0;
-  border-top: 1px solid rgba(37, 40, 43, 0.1); }
 
 a,
 .f-a {
@@ -92,6 +86,11 @@ a,
   a:hover,
   .f-a:hover {
     text-decoration: underline; }
+
+hr {
+  margin-bottom: 23px;
+  border: 0;
+  border-top: 1px solid rgba(37, 40, 43, 0.1); }
 
 .o-wrap {
   display: block;
@@ -1733,6 +1732,12 @@ select.c-input {
 
 .u-font-nowrap {
   white-space: nowrap; }
+
+.u-font-caps {
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  -webkit-font-feature-settings: "c2sc" 1, "smcp" 1;
+          font-feature-settings: "c2sc" 1, "smcp" 1; }
 
 .u-thide {
   overflow: hidden;

--- a/css/scooter.css.orig
+++ b/css/scooter.css.orig
@@ -1593,6 +1593,7 @@ select.c-input {
   margin-left: 64px !important;
   margin-right: 64px !important; }
 
+<<<<<<< 8535da0aa7cbd9a0cdf282c3e43b5beac6d61995
 .u-pad-xxl {
   padding: 96px !important; }
 
@@ -1685,6 +1686,8 @@ select.c-input {
   margin-left: 128px !important;
   margin-right: 128px !important; }
 
+=======
+>>>>>>> Rewrite typography section, move margin/padding trim helpers upstream
 .u-l-fl {
   float: left !important; }
 

--- a/docs/source/assets/css/base/_typography.scss
+++ b/docs/source/assets/css/base/_typography.scss
@@ -46,7 +46,6 @@ h4 {
   font-weight: 500;
   font-feature-settings: "c2sc" 1, "smcp" 1;
   line-height: 1;
-  letter-spacing: .075em;
 
   color: #7B8994;
 }

--- a/docs/source/assets/css/demo.scss
+++ b/docs/source/assets/css/demo.scss
@@ -49,6 +49,18 @@
     }
   }
 }
+.sc-demo--margin {
+    .sc-demo__output {
+        div {
+            background-color: rgba(#7b8944, .2);
+            overflow: hidden;
+
+            [class*="u-mar-"] {
+                background-color: rgba(#7b8944, .2);
+            }
+        }
+    }
+}
 
 // Color pallette demo styles
 @import "../../../../scss/variables/colors";

--- a/docs/source/base.erb
+++ b/docs/source/base.erb
@@ -41,21 +41,27 @@ toc:
     <em>look</em> like a <code>h1</code> without changing its semantic value, you
     can add a class of <code>f-alpha</code> to the element.</p>
 
-  <%= code_example('<h1>This is a level 1 heading</h1>
+  <%= code_example('<small class="u-font-small u-font-caps u-font-meta u-font-strong">f-headline (48px)</small>
+<h1 class="f-headline">This is a headline</h1>
 
-<h2>A level 2 heading</h2>
+<small class="u-font-small u-font-caps u-font-meta u-font-strong">f-subhead (36px)</small>
+<h1 class="f-subhead">This is a subheading</h1>
 
-<h3>A level 3 heading</h3>
+<small class="u-font-small u-font-caps u-font-meta u-font-strong">f1 (24px)</small>
+<h1 class="f1">This is a first-level heading</h1>
 
-<h4>A level 4 heading</h4>
+<small class="u-font-small u-font-caps u-font-meta u-font-strong">f2 (20px)</small>
+<h2 class="f2">A second-level heading</h2>
+
+<small class="u-font-small u-font-caps u-font-meta u-font-strong">f3 (16px)</small>
+<h3 class="f3">A third-level heading</h3>
+
+<small class="u-font-small u-font-caps u-font-meta u-font-strong">f4 (13px)</small>
+<h4 class="f4">A fourth-level heading</h4>
 
 <p>This is a paragraph.</p>
 
 <p>This is a paragraph <a href="#">with a link</a>.</p>
 
-<hr/>
-
-<span class="f-alpha">This is a span with the appearance of h1</span>
-
-<span class="f-beta">This is a span with the appearance of h2</span>')%>
+<hr class="c-rule"/>')%>
 </section>

--- a/docs/source/base.erb
+++ b/docs/source/base.erb
@@ -36,27 +36,32 @@ toc:
     <%= gh_link("base/_typography.scss") %>
   </header>
 
-  <p><code>base/typography</code> sets default styles for typographic elements and
-    adds classes for those styles. For example, if you want a piece of text to
-    <em>look</em> like a <code>h1</code> without changing its semantic value, you
-    can add a class of <code>f-alpha</code> to the element.</p>
+  <p><code>base/typography</code> provides a suite of typographic styles for headings,
+    links, and horizontal rules.</p>
 
-  <%= code_example('<small class="u-font-small u-font-caps u-font-meta u-font-strong">f-headline (48px)</small>
+  <p>Heading tags (<code>h1, h2</code>, etc.) are not directly styled. Instead,
+    classes are used to style headings at different levels to allow style to be
+    completely separated from document semantics.</p>
+
+  <p>This also allows designers and engineers to use a common vocabulary when describing
+    type sizes. The type scale and corresponding HTML classes can be seen below.</p>
+
+  <%= code_example('<code class="u-font-meta">.f-headline (48px)</code>
 <h1 class="f-headline">This is a headline</h1>
 
-<small class="u-font-small u-font-caps u-font-meta u-font-strong">f-subhead (36px)</small>
+<code class="u-font-meta">.f-subhead (36px)</code>
 <h1 class="f-subhead">This is a subheading</h1>
 
-<small class="u-font-small u-font-caps u-font-meta u-font-strong">f1 (24px)</small>
+<code class="u-font-meta">.f1 (24px)</code>
 <h1 class="f1">This is a first-level heading</h1>
 
-<small class="u-font-small u-font-caps u-font-meta u-font-strong">f2 (20px)</small>
+<code class="u-font-meta">.f2 (20px)</code>
 <h2 class="f2">A second-level heading</h2>
 
-<small class="u-font-small u-font-caps u-font-meta u-font-strong">f3 (16px)</small>
+<code class="u-font-meta">.f3 (16px)</code>
 <h3 class="f3">A third-level heading</h3>
 
-<small class="u-font-small u-font-caps u-font-meta u-font-strong">f4 (13px)</small>
+<code class="u-font-meta">.f4 (13px)</code>
 <h4 class="f4">A fourth-level heading</h4>
 
 <p>This is a paragraph.</p>

--- a/docs/source/components.erb
+++ b/docs/source/components.erb
@@ -356,7 +356,7 @@ toc:
   <%= code_example('<div class="c-modal-overlay">
   <div class="c-modal">
     <div class="c-modal__header">
-      <h2>Modal title</h2>
+      <h2 class="f2">Modal title</h2>
     </div>
     <div class="c-modal__content">
       <p>This is some content inside the modal.</p>
@@ -370,7 +370,7 @@ toc:
 <%= code_example('<div class="c-modal-overlay">
   <div class="c-modal c-modal--unibody">
     <div class="c-modal__header">
-      <h2>Modal title</h2>
+      <h2 class="f2">Modal title</h2>
     </div>
     <div class="c-modal__content">
       <p>This is some content inside the modal.</p>

--- a/docs/source/utilities.erb
+++ b/docs/source/utilities.erb
@@ -33,6 +33,19 @@ toc:
     <%= gh_link("helpers/_layout.scss") %>
   </header>
 
+  <p>Margins and padding have helpers with &ldquo;tshirt&rdquo; sizes for adding space between elements.</p>
+
+  <ul>
+    <li><code>xxs: 4px</code></li>
+    <li><code>xs: 8px</code></li>
+    <li><code>s: 16px</code></li>
+    <li><code>m: 24px</code></li>
+    <li><code>l: 32px</code></li>
+    <li><code>xl: 64px</code></li>
+    <li><code>xxl: 96px</code></li>
+    <li><code>jumbo: 128px</code></li>
+  </ul>
+
   <h3>Padding</h3>
   <%= code_example('<p>
   <span class="u-pad-m">Regular padding</span>
@@ -44,39 +57,56 @@ toc:
   <span class="u-pad-xs">Extra-small padding</span>
 </p>
 <p>
+  <span class="u-pad-xxs">Double-extra-small padding</span>
+</p>
+<p>
   <span class="u-pad-l">Large padding</span>
 </p>
 <p>
   <span class="u-pad-xl">Extra-large padding</span>
+</p>
+<p>
+  <span class="u-pad-xxl">Double-extra-large padding</span>
+</p>
+<p>
+  <span class="u-pad-jumbo">Jumbo padding</span>
 </p>', "padding") %>
 
-  <p>You can also add a <code>vertical</code> or <code>horizontal</code> keyword to apply vertical or horizontal padding:</p>
+  <p>You can also add a <code>vertical</code> or <code>horizontal</code> keyword to apply vertical or horizontal padding,
+    as well as edge keywords <code>top, right, bottom</code> or <code>left</code> to add padding to that edge:</p>
 
-  <%= code_example('<span class="u-pad-vertical-m">Regular vertical padding</span>', "padding") %>
+  <%= code_example('<p>
+  <span class="u-pad-vertical-m">Regular vertical padding</span>
+</p>
+<p>
+  <span class="u-pad-left-xl">Extra-large left padding</span>
+</p>',"padding") %>
 
   <h3>Margins</h3>
-  <p>Use margin classes to add or remove margins to elements when they don't have any of their own.</p>
+  <p>Margins have the same tshirt sizes available. (Note that paragraphs always get a margin-bottom by default in these
+    demos).</p>
 
-  <p>As an example, take a look at the <code>u-l-mb</code> classes below. <code>mb</code> indicates that the class is
-    affecting the <code>m</code>argin <code>b</code>ottom. There are margin helpers available for each side: top, right,
-    bottom, and left (<code>mt</code>, <code>mr</code>, <code>mb</code>, and <code>ml</code> respectively).</p>
-
-  <p>There are also modifiers that can be appended to determine the size of the margin, ranging from extra-small
-    <code>xs</code> to extra-large <code>xl</code>.</p>
-
-  <%= code_example('<div class="u-mar-bottom-m">This has a margin-bottom equal to the baseline</div>
+  <%= code_example('<div>
+  <p class="u-mar-bottom-m">This has a medium bottom margin</p>
+</div>
 
 <hr/>
 
-<div class="u-mar-bottom-l">This has a double-height margin-bottom</div>
+<div>
+  <p class="u-mar-vertical-l">This has a large vertical margin</p>
+</div>
 
 <hr/>
 
-<div class="u-mar-bottom-s">This has a half-height margin-bottom</div>
+<div>
+  <p class="u-mar-right-s">This has a small right margin</p>
+</div>
 
 <hr/>
 
-<p class="u-trim-margin">This paragraph has been trimmed of its margin</p>') %>
+<div>
+  <p class="u-trim-margin">This paragraph has been trimmed of its margin</p>
+</div>', "margin") %>
 
   <h3>Floats</h3>
   <p>You can float things left and right with ease. Don't forget to put floated

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -5,87 +5,87 @@
 //
 //---------------------------
 
-@mixin scooter-type() {
-    // Headings
-    // ========
-    //
-    // Only h1-h4 are used/styled. If your DOM heirarchy goes as deep at h5 or h6,
-    // you have some rethinking to do.
-    //
-    h1,
-    %f-alpha,
-    .f-alpha {
-        display: block;
-        margin-bottom: $DBbaseline;
-
-        font-size: 28px;
-        font-weight: 200;
-        line-height: 36px;
+@mixin scoped-type() {
+    hr {
+        @extend %hr;
     }
 
-    h2,
-    %f-beta,
-    .f-beta {
-        display: block;
-        margin-bottom: $DBbaseline;
-
-        font-size: 20px;
-        font-weight: 400;
-        line-height: 28px;
+    a {
+        @extend %f-a;
     }
+}
 
-    h3,
-    %f-gamma,
-    .f-gamma {
-        display: block;
-        margin-bottom: $DBbaseline;
+// Headings
+// ========
+//
+.f-headline, .f-subhead,
+.f1, .f2, .f3, .f4 {
+    display: block;
+    margin-bottom: $DBbaseline;
 
-        font-size: 16px;
-        font-weight: 400;
-        line-height: 28px;
+    font-weight: 400;
+    line-height: 1.25;
+}
+
+.f-headline {
+    font-size: 48px;
+    font-weight: 200;
+}
+
+.f-subhead {
+    font-size: 36px;
+    font-weight: 200;
+}
+
+.f1 {
+    font-size: 24px;
+}
+
+.f2 {
+    font-size: 20px;
+}
+
+.f3 {
+    font-size: 16px;
+}
+
+.f4 {
+    margin-bottom: 0;
+
+    font-size: 13px;
+    font-weight: 600;
+    line-height: $DBbaseline;
+}
+
+// Links
+%f-a,
+.f-a,
+.f-link {
+    text-decoration: none;
+
+    color: color(blue);
+
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
     }
+}
 
-    h4,
-    %f-delta,
-    .f-delta {
-        display: block;
+// TODO:dte
+// Deprecate the %hr element in favor of the c-rule component
+%hr {
+    margin-bottom: $DBbaseline;
 
-        font-size: 13px;
-        font-weight: 600;
-        line-height: $DBbaseline;
-    }
-
-    // Other type styles
-    // =================
-    //
-    hr,
-    %hr{
-        margin-bottom: $DBbaseline;
-
-        border: 0;
-        border-top: 1px solid color(gray, x-dark, 0.1);
-    }
-
-    a,
-    %f-a,
-    .f-a {
-        text-decoration: none;
-
-        color: color(blue);
-
-        cursor: pointer;
-
-        &:hover {
-            text-decoration: underline;
-        }
-    }
+    border: 0;
+    border-top: 1px solid color(gray, x-dark, 0.1);
 }
 
 @if ($DBscope-scooter-reset == true) {
     .scooter-css {
-        @include scooter-type;
+        @include scoped-type;
     }
 } @else {
-    @include scooter-type;
+    @include scoped-type;
 }
 

--- a/scss/components/__all.scss
+++ b/scss/components/__all.scss
@@ -19,3 +19,4 @@
 @import "title-bubble";
 @import "tokens";
 @import "typeahead";
+@import "rules";

--- a/scss/components/_rules.scss
+++ b/scss/components/_rules.scss
@@ -1,0 +1,14 @@
+//-----------------------------
+//
+// Horizontal Rule Component
+//
+//-----------------------------
+
+$DBrule-namespace: "c-rule";
+
+.#{$DBrule-namespace} {
+    margin-bottom: $DBbaseline;
+
+    border: 0;
+    border-top: 1px solid color(gray, x-dark, 0.1);
+}

--- a/scss/helpers/_layout.scss
+++ b/scss/helpers/_layout.scss
@@ -26,6 +26,14 @@ $DBspacing-edges: (
   'horizontal' ('left' 'right')
 );
 
+.u-trim-margin {
+    margin: 0 !important;
+}
+
+.u-trim-padding {
+    padding: 0 !important;
+}
+
 @each $size, $scale in $DBspacing-sizes {
 
   .u-pad-#{$size} {
@@ -59,16 +67,6 @@ $DBspacing-edges: (
       }
     }
   }
-}
-
-
-
-.u-trim-margin {
-    margin: 0 !important;
-}
-
-.u-trim-padding {
-    padding: 0 !important;
 }
 
 // Floats

--- a/scss/helpers/_layout.scss
+++ b/scss/helpers/_layout.scss
@@ -14,7 +14,9 @@ $DBspacing-sizes: (
   's': 1,
   'm': 1.5,
   'l': 2,
-  'xl': 4
+  'xl': 4,
+  'xxl': 6,
+  'jumbo': 8
 );
 
 $DBspacing-edges: (
@@ -25,6 +27,14 @@ $DBspacing-edges: (
   'vertical' ('top' 'bottom'),
   'horizontal' ('left' 'right')
 );
+
+.u-trim-margin {
+    margin: 0 !important;
+}
+
+.u-trim-padding {
+    padding: 0 !important;
+}
 
 @each $size, $scale in $DBspacing-sizes {
 
@@ -59,16 +69,6 @@ $DBspacing-edges: (
       }
     }
   }
-}
-
-
-
-.u-trim-margin {
-    margin: 0 !important;
-}
-
-.u-trim-padding {
-    padding: 0 !important;
 }
 
 // Floats

--- a/scss/helpers/_typography.scss
+++ b/scss/helpers/_typography.scss
@@ -64,6 +64,13 @@
     white-space: nowrap;
 }
 
+.u-font-caps,
+%u-font-caps {
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    font-feature-settings: "c2sc" 1, "smcp" 1;
+}
+
 // Hide text in element
 // Useful for icons with screenreader-accessible text
 .u-thide {

--- a/scss/helpers/_typography.scss
+++ b/scss/helpers/_typography.scss
@@ -25,6 +25,7 @@
 .u-font-small,
 %u-font-small {
     font-size: 0.85em;
+    line-height: 1.8;
 }
 
 .u-font-strong,


### PR DESCRIPTION
Redesigning Scooter's type scale to:
## Be less prescriptive about the semantics of typographic DOM elements used

Currently, Scooter styles `h1-h4` tags in addition to matching class names. This means a few things:
- Developers either have to break document semantics to make their `h1` look like a `h2` by changing the tag **or**
- Developers have to use more classes than reasonably necessary to override styles and make their typographic elements reflect the appearance of `h1`, etc.

This PR removes styles from `hn` tags and just provides classes instead, allowing complete separation of style and semantics.
## Offer a larger, more flexible type scale

The type scale was also constrained to Dropbox's in-product type scale (`h1-h4`) and provided no base styles for, say, marketing design.

This PR introduces two new type styles—heading and subhead—to supplement the standard/product type scale. It also aligns the type scale with more reasonable/traditional scale numbers for a more harmonic design scale.

Screenshot of the new type scale:
![](https://www.dropbox.com/s/vf5br4i8nlxel8l/Screenshot%202016-04-26%2017.10.36.png?dl=1)
